### PR TITLE
Fixed usable hint

### DIFF
--- a/WinboxExploit.py
+++ b/WinboxExploit.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
      try:
           ip = sys.argv[1]
      except:
-          print("Usage: python PoC.py [IP_ADDRESS]")
+          print("Usage: python WinboxExploit.py [IP_ADDRESS]")
 
      #Initialize Socket
      s = socket.socket()


### PR DESCRIPTION
`PoC.py` was renamed to `WinboxExploit.py`, but the filename was not changed in the usage hint. This is now fixed.

The linebreak change at the end is just a GitHub editor thing.