### PR TITLE
Fixed crash from Winbox accesslisted routers

### DIFF
--- a/WinboxExploit.py
+++ b/WinboxExploit.py
@@ -56,7 +56,11 @@ if __name__ == "__main__":
 
      #Send hello and recieve the sesison id
      s.send(a)
-     d = bytearray(s.recv(1024))
+     try:
+         d = bytearray(s.recv(1024))
+     except Exception as e:
+         print("Connection error: " + str(e))
+         exit()
 
      #Replace the session id in template
      b[19] = d[38]


### PR DESCRIPTION
When "/ip service set winbox address=#" is set, it causes the script to crash when the socket is reset. This is now handled.

It will now show as:
![image](https://user-images.githubusercontent.com/2676134/48560001-23c7f400-e8ed-11e8-8b07-09d1fdb787ae.png)

Fixes #24